### PR TITLE
Add KiCad-RW Python library to read/write KiCad Sexpr file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ These are libraries/packages/modules that can help when creating tools like the 
 
 - [kicad-utils](https://github.com/cho45/kicad-utils) - KiCAD library / schematic / pcb parser and plotter written in TypeScript (JavaScript)
 
-- [KiCad-RW](https://github.com/FabriceSalvaire/kicad-rw) - A Python library to read/write KiCad 6 Sexpr file format. (Implement actually a `.kicad_sch` reader)
+- [KiCad-RW](https://github.com/FabriceSalvaire/kicad-rw) - A Python library to read/write KiCad 6 Sexpr file format. In addition this library can compute the netlist of a circuit. (It actually only implements a `.kicad_sch` reader)
 
 ## Cheatsheets
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ These are libraries/packages/modules that can help when creating tools like the 
 
 - [kicad-utils](https://github.com/cho45/kicad-utils) - KiCAD library / schematic / pcb parser and plotter written in TypeScript (JavaScript)
 
+- [KiCad-RW](https://github.com/FabriceSalvaire/kicad-rw) - A Python library to read/write KiCad 6 Sexpr file format. (Implement actually a `.kicad_sch` reader)
+
 ## Cheatsheets
 
 These are handy guides for using KiCad and related tools.


### PR DESCRIPTION
Just coded a (Python library) proof of concept to read KiCad 6 `.kicad_sch` file, as far I know there is actually any library that handle this format.

[pykicad](https://github.com/dvc94ch/pykicad) handles `.kicad_pcb`, but it is no longer active. And I use sexpdata to parse Sexpr. pykicad implements its own parser.

Reorder the list as you want...

See https://github.com/FabriceSalvaire/kicad-rw